### PR TITLE
Update federate class metadata manager creation

### DIFF
--- a/src/cosim_toolbox/sims/federate.py
+++ b/src/cosim_toolbox/sims/federate.py
@@ -104,9 +104,6 @@ class Federate:
         self.stop_time = -1.0
         self.granted_time = -1.0
         self.next_requested_time = -1.0
-        self.pubs = {}
-        self.inputs = {}
-        self.endpoints = {}
         self.debug = True
 
         # Internal State Attributes
@@ -217,19 +214,20 @@ class Federate:
             raise NameError("scenario_name is None")
         self.scenario_name = scenario_name
 
-        with create_metadata_manager(use_meta_db) as mgr:
-            self.scenario = mgr.read_scenario(self.scenario_name)
-            if not self.scenario:
-                raise ValueError(f"Scenario '{self.scenario_name}' not found in metadata store.")
-            self.analysis_name = self.scenario.get("analysis")
-            if not self.analysis_name:
-                raise ValueError(f"Scenario '{self.scenario_name}' does not specify a 'analysis'.")
-            self.federation_name = self.scenario.get("federation")
-            if not self.federation_name:
-                raise ValueError(f"Scenario '{self.scenario_name}' does not specify a 'federation'.")
-            self.federation = mgr.read_federation(self.federation_name)['federation']
-            if not self.federation:
-                raise ValueError(f"Federation '{self.federation_name}' not found in metadata store.")
+        md_mgr = create_metadata_manager(use_meta_db)
+        self.metadata_manager = md_mgr
+        self.scenario = md_mgr.read_scenario(self.scenario_name)
+        if not self.scenario:
+            raise ValueError(f"Scenario '{self.scenario_name}' not found in metadata store.")
+        self.analysis_name = self.scenario.get("analysis")
+        if not self.analysis_name:
+            raise ValueError(f"Scenario '{self.scenario_name}' does not specify a 'analysis'.")
+        self.federation_name = self.scenario.get("federation")
+        if not self.federation_name:
+            raise ValueError(f"Scenario '{self.scenario_name}' does not specify a 'federation'.")
+        self.federation = md_mgr.read_federation(self.federation_name)['federation']
+        if not self.federation:
+            raise ValueError(f"Federation '{self.federation_name}' not found in metadata store.")
 
         self.set_metadata()
         self.get_helics_config()

--- a/src/cosim_toolbox/sims/federate.py
+++ b/src/cosim_toolbox/sims/federate.py
@@ -670,6 +670,8 @@ class Federate:
         if self.timeseries_manager:
             self.timeseries_manager.flush()
             self.timeseries_manager.disconnect()
+        if self.metadata_manager:
+            self.metadata_manager.disconnect()
         h.helicsFederateClearMessages(self.hfed)
         # TODO: there is a bug for h.helicsFederateRequestTime
         # requested_time = int(h.helicsFederateRequestTime)


### PR DESCRIPTION
Modify federate class so that metadata manager is assigned as a persistent attribute of the class and is accessible by users.

(Also removed some redundant class attribute dictionaries.)